### PR TITLE
Set `pattern` to `'(assemble|install|bundle)(\\w+?)(Release|Debug)?(]…

### DIFF
--- a/variantTemplate/android/build.gradle
+++ b/variantTemplate/android/build.gradle
@@ -41,7 +41,7 @@ def getCurrentFlavor() {
     Gradle gradle = getGradle()
     String  tskReqStr = gradle.getStartParameter().getTaskRequests().toString()
     Pattern pattern;
-    pattern = Pattern.compile("(assemble|install|bundle)(\\w+)(Release|Debug)")
+    pattern = Pattern.compile('(assemble|install|bundle)(\\w+?)(Release|Debug)?(]|\$)')
 
     Matcher matcher = pattern.matcher( tskReqStr )
 


### PR DESCRIPTION
…|\$)'`;

Some users will run `$ ./gradlew assembleCasadoconcurseiro` not adding `Release` or `Debug`;
Fixes `Variant folder not found` error;